### PR TITLE
Update templates

### DIFF
--- a/roles/cisco/templates/interface_edge.cfg.j2
+++ b/roles/cisco/templates/interface_edge.cfg.j2
@@ -43,6 +43,10 @@ interface {{ interface }}
 {% else %}
  power inline never
 {% endif %}
+
+ storm-control broadcast level bps 3000000
+ storm-control unicast level bps 3000000
+ storm-control multicast level bps 3000000
 {% endif %}
 
 {% if prop.trunk_all %}

--- a/roles/juniper/templates/interface_edge.cfg.j2
+++ b/roles/juniper/templates/interface_edge.cfg.j2
@@ -31,10 +31,16 @@ set interfaces {{ interface }} description "{{ prop.description }}"
 
 {% if prop.physical and not prop.lag_member %}
 set interfaces {{ interface }} unit 0 family ethernet-switching storm-control default
+set interfaces {{ interface }} unit 0 family ethernet-switching storm-control "storm3M"
+
+set interfaces {{ interface }} unit 0 family ethernet-switching filter input-list DEFAULT
+set interfaces {{ interface }} unit 0 family ethernet-switching filter output-list DEFAULT
+set interfaces {{ interface }} unit 0 family ethernet-switching filter input-list CDP
+set interfaces {{ interface }} unit 0 family ethernet-switching filter output-list CDP
 
 {% if prop.bpdu_filter %}
-set interfaces {{ interface }} unit 0 family ethernet-switching filter input BPDU_FILTER
-set interfaces {{ interface }} unit 0 family ethernet-switching filter output BPDU_FILTER
+set interfaces {{ interface }} unit 0 family ethernet-switching filter input-list BPDU
+set interfaces {{ interface }} unit 0 family ethernet-switching filter output-list BPDU
 {% endif %}
 
 {% if prop.speed_10m %}


### PR DESCRIPTION
```
[Stome-control]
- juniper
set interfaces {{ interface }} unit 0 family ethernet-switching storm-control "storm3M"

以下の設定をoverwriteで投入予定
set forwarding-options storm-control-profiles storm3M all bandwidth-level 3000
set forwarding-options storm-control-profiles storm3M-no-reg all no-registered-multicast bandwidth-level 3000

- cisco
storm-control broadcast level bps 3000000
storm-control unicast level bps 3000000
storm-control multicast level bps 3000000


[BPDU] *input BPDU_FILTER を input-list BPDU に変更
set interfaces {{ interface }} unit 0 family ethernet-switching filter input-list BPDU
set interfaces {{ interface }} unit 0 family ethernet-switching filter output-list BPDU

以下の設定をoverwriteで投入予定
set firewall family ethernet-switching filter BPDU term descard_bpdu from destination-mac-address 01:80:c2:00:00:00/48
set firewall family ethernet-switching filter BPDU term descard_bpdu from destination-mac-address 01:00:0c:cc:cc:cd/48
set firewall family ethernet-switching filter BPDU term descard_bpdu then discard
set firewall family ethernet-switching filter BPDU term default then accept


[CDP]
set interfaces {{ interface }} unit 0 family ethernet-switching filter input-list CDP
set interfaces {{ interface }} unit 0 family ethernet-switching filter output-list CDP

以下の設定をoverwriteで投入予定
set firewall family ethernet-switching filter CDP term discard_cdp from destination-mac-address 01:00:0c:cc:cc:cc/48
set firewall family ethernet-switching filter CDP term discard_cdp then discard
set firewall family ethernet-switching filter CDP term default then accept

[DEFAULT]
set interfaces ae11 unit 0 family ethernet-switching filter input-list DEFAULT
set interfaces ae11 unit 0 family ethernet-switching filter output-list DEFAULT

以下の設定をoverwriteで投入予定
set firewall family ethernet-switching filter DEFAULT term default then accept
```