### PR TITLE
Fix #94

### DIFF
--- a/project/roles/cisco/templates/include/clear.j2
+++ b/project/roles/cisco/templates/include/clear.j2
@@ -1,8 +1,10 @@
  no description
  no switchport
  no ip address
- no lldp transmit
- no lldp receive
  no storm-control broadcast level
  no storm-control multicast level
  no storm-control unicast level
+{% if interface.is_physical %}
+ no lldp transmit
+ no lldp receive
+{% endif %}

--- a/project/roles/cisco/templates/include/interface-lldp.j2
+++ b/project/roles/cisco/templates/include/interface-lldp.j2
@@ -1,7 +1,7 @@
 {% if interface.is_phy_uplink or interface.is_to_ap %}
  lldp transmit
  lldp receive
-{% else %}
+{% elif interface.is_physical %}
  no lldp transmit
  no lldp receive
 {% endif %}

--- a/project/roles/cisco/templates/include/interface-poe.j2
+++ b/project/roles/cisco/templates/include/interface-poe.j2
@@ -1,5 +1,7 @@
-{% if interface.is_utp and interface.is_poe %}
+{% if interface.is_utp %}
+{% if interface.is_poe %}
  power inline auto
 {% else %}
  power inline never
+{% endif %}
 {% endif %}

--- a/project/roles/cisco/templates/include/interface-storm.j2
+++ b/project/roles/cisco/templates/include/interface-storm.j2
@@ -1,4 +1,5 @@
-{% if interface.is_physical and not interface.is_phy_uplink and not interface.is_to_ap %}
+{% if not interface.is_lag_member %}
+{% if interface.is_physical %}
  storm-control broadcast level bps 3000000
  storm-control multicast level bps 3000000
  no storm-control unicast level
@@ -6,4 +7,5 @@
  no storm-control broadcast level
  no storm-control multicast level
  no storm-control unicast level
+{% endif %}
 {% endif %}


### PR DESCRIPTION
エラーになるシチュエーションを回避するテンプレートに修正した。
Storm-control：
　LAGメンバには何もしない
　enableの物理IFすべてにStorm-controlを設定
　その他のIFにはStorm-control削除処理
LLDP：
　enableなLAGメンバおよびAP接続IFでLLDP有効化
　その他の物理IFにてLLDP無効化
　Port-channel IFには何もしない
PoE：
　enableなUTPでPoEタグがあるものにpower inline auto
　他のenableなUTP IFはpower inline never
　UTP以外のIFでは何もしない