### PR TITLE
Fix #103

### DIFF
--- a/lib/tn4/cli/doctor.py
+++ b/lib/tn4/cli/doctor.py
@@ -200,6 +200,10 @@ class Doctor(CommandBase):
             self.console.log(f"[yellow]Checked tag-to-tag confliction [dim]({i} of {n})")
 
             i += 1
+            self.cap.diagnose.check_and_clear_incomplete_interfaces()
+            self.console.log(f"[yellow]Checked incomplete interfaces [dim]({i} of {n})")
+
+            i += 1
             self.cap.diagnose.check_and_clear_obsoleted_interfaces()
             self.console.log(f"[yellow]Checked obsoleted interfaces [dim]({i} of {n})")
 
@@ -214,10 +218,6 @@ class Doctor(CommandBase):
             i += 1
             self.cap.diagnose.check_vlan_group_consistency()
             self.console.log(f"[yellow]Checked VLAN group consistency [dim]({i} of {n})")
-
-            i += 1
-            self.cap.diagnose.check_and_clear_incomplete_interfaces()
-            self.console.log(f"[yellow]Checked incomplete interfaces [dim]({i} of {n})")
 
             i += 1
             self.cap.diagnose.check_and_remove_empty_irb()

--- a/lib/tn4/doctor/diagnose.py
+++ b/lib/tn4/doctor/diagnose.py
@@ -211,6 +211,14 @@ class Diagnose():
                 if current.has_tag(Slug.Tag.Keep):
                     continue
 
+                ## skip if the interface has 'Wi-Fi' tag
+                if current.has_tag(Slug.Tag.Wifi):
+                    continue
+
+                ## skip if the interface has 'Hosting' tag
+                if current.has_tag(Slug.Tag.Hosting):
+                    continue
+
                 ## skip if the interface is a LAG child
                 if current.is_lag_member:
                     continue


### PR DESCRIPTION
check_and_clear_incomplete_interfaces()にてWi-Fi tagとHosting tagを除外
先のlib/tn4/cli/doctor.pyへの修正を取り消し