### PR TITLE
Fix #111

### DIFF
--- a/project/roles/juniper/templates/include/core/reset.j2
+++ b/project/roles/juniper/templates/include/core/reset.j2
@@ -4,9 +4,5 @@ delete vlans
 delete interfaces {{ interface.name }} unit 0
 {% endfor %}
 
-{% for unit in unprotected_irb_units %}
-delete interfaces irb unit {{ unit }}
-{% endfor %}
-
 set protocols lldp interface all
 

--- a/project/roles/juniper/templates/include/core/set-interfaces-address.j2
+++ b/project/roles/juniper/templates/include/core/set-interfaces-address.j2
@@ -1,19 +1,12 @@
+{% if not interface.is_irb %}
+
 {% for ip in interface.addresses4 %}
-{% if interface.name[:3] != "irb" %}
 set interfaces {{ interface.name }} unit 0 family inet address {{ ip }}
-{#
-{% else %}
-set interfaces irb unit {{ interface.name[4:] }} family inet address {{ ip }}
-#}
-{% endif %}
 {% endfor %}
 
 {% for ip in interface.addresses6 %}
-{% if interface.name[:4] != "irb" %}
-set interfaces irb unit {{ interface.name[4:] }} family inet6 address {{ ip }}
-{#
-{% else %}
 set interfaces {{ interface.name }} unit 0 family inet6 address {{ ip }}
-#}
-{% endif %}
 {% endfor %}
+
+{% endif %}
+

--- a/project/roles/juniper/templates/include/core/set-interfaces-branch.j2
+++ b/project/roles/juniper/templates/include/core/set-interfaces-branch.j2
@@ -1,9 +1,4 @@
-{% for ifname, interface in interfaces.items() %}
 {% if interface.is_irb and interface.is_deploy_target %}
-
-set protocols rip group shisen neighbor {{ ifname }}
-set protocols router-advertisement interface {{ ifname }} virtual-router-only
-set protocols router-advertisement interface {{ ifname }} prefix {{ interface.ra_prefix }}
 
 set interfaces irb unit {{ interface.unit_number }} apply-groups {{ interface.apply_groups }}
 set interfaces irb unit {{ interface.unit_number }} description {{ interface.description }}
@@ -11,12 +6,16 @@ set interfaces irb unit {{ interface.unit_number }} description {{ interface.des
 {% if interface.vrrp_physical_ip4 %}
 set interfaces irb unit {{ interface.unit_number }} family inet mtu {{ interface.mtu }}
 set interfaces irb unit {{ interface.unit_number }} family inet address {{ interface.vrrp_physical_ip4 }} vrrp-group {{ interface.vrrp_group_id }} virtual-address {{ interface.vrrp_virtual_ip4 }}
+set protocols rip group shisen neighbor {{ interface.name }}
 {% endif %}
 
 {% if interface.vrrp_physical_ip6 %}
 set interfaces irb unit {{ interface.unit_number }} family inet6 mtu {{ interface.mtu }}
 set interfaces irb unit {{ interface.unit_number }} family inet6 address {{ interface.vrrp_physical_ip6 }} vrrp-inet6-group {{ interface.vrrp_group_id }} virtual-inet6-address {{ interface.vrrp_virtual_ip6 }}
+set protocols ripng group shisen neighbor {{ interface.name }}
+set protocols router-advertisement interface {{ interface.name }} virtual-router-only
+set protocols router-advertisement interface {{ interface.name }} prefix {{ interface.ra_prefix }}
 {% endif %}
 
 {% endif %}
-{% endfor %}
+


### PR DESCRIPTION
- 追加したIRB設定が他のIF設定で何度も追加される
- IPv6の設定時にRIPng設定に追加されない
- IPv6設定がない場合でもRAの設定が実施される
これらの修正を`set-interfaces-branch.j2`に実施。

- BRANCH_IDがなくてもIPv6アドレス設定だけIRB IFで実施される
`set-interfaces-address.j2`からirbのアドレス設定を削除（IPv6のirb IF判定に誤りがあった）。

その他、現状では、Branch IDをすべてのirb IFに定義していないので、`reset.j2`からdelete interface irbを一旦削除。
rip, ripng, RAの設定削除と合わせて、実装方法を再検討する。